### PR TITLE
feat: Add ms-database service with libSQL/sqld

### DIFF
--- a/charts/pvpipe/Chart.yaml
+++ b/charts/pvpipe/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pvpipe
 description: A Helm chart for PVPipe deployment with Traefik API Gateway
-version: 0.30.3
+version: 0.30.4
 appVersion: "1.5.0"
 
 dependencies:

--- a/charts/pvpipe/templates/core/common-env-configmap.yaml
+++ b/charts/pvpipe/templates/core/common-env-configmap.yaml
@@ -38,3 +38,9 @@ data:
   {{- if .Values.localsignpdf.enabled }}
   LOCALSIGNPDF_URL: "http://{{ .Release.Name }}-localsignpdf:8080"
   {{- end }}
+  # MS-Database (libSQL/sqld) connection
+  {{- if .Values.msDatabase.enabled }}
+  MS_DATABASE_URL: "http://{{ .Release.Name }}-ms-database:{{ .Values.msDatabase.sqldPort }}"
+  MS_DATABASE_VIEWER_URL: "http://{{ .Release.Name }}-ms-database:{{ .Values.msDatabase.viewerPort }}"
+  SQLD_HTTP_URL: "http://{{ .Release.Name }}-ms-database:{{ .Values.msDatabase.sqldPort }}"
+  {{- end }}

--- a/charts/pvpipe/templates/services/ms-database/service.yaml
+++ b/charts/pvpipe/templates/services/ms-database/service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.msDatabase.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pvpipe.fullname" . }}-ms-database
+  labels:
+    {{- include "pvpipe.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ms-database
+spec:
+  type: ClusterIP
+  ports:
+  - name: sqld
+    port: {{ .Values.msDatabase.sqldPort }}
+    targetPort: sqld
+    protocol: TCP
+  - name: viewer
+    port: {{ .Values.msDatabase.viewerPort }}
+    targetPort: viewer
+    protocol: TCP
+  selector:
+    {{- include "pvpipe.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ms-database
+{{- end }}

--- a/charts/pvpipe/templates/services/ms-database/statefulset.yaml
+++ b/charts/pvpipe/templates/services/ms-database/statefulset.yaml
@@ -1,0 +1,130 @@
+{{- if .Values.msDatabase.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "pvpipe.fullname" . }}-ms-database
+  labels:
+    {{- include "pvpipe.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ms-database
+spec:
+  serviceName: {{ include "pvpipe.fullname" . }}-ms-database
+  replicas: {{ .Values.msDatabase.replicas }}
+  selector:
+    matchLabels:
+      {{- include "pvpipe.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ms-database
+  template:
+    metadata:
+      labels:
+        {{- include "pvpipe.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ms-database
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecrets }}
+      {{- end }}
+      containers:
+      - name: ms-database
+        image: "{{ .Values.msDatabase.image.repository }}:{{ .Values.msDatabase.image.tag }}"
+        imagePullPolicy: {{ .Values.msDatabase.image.pullPolicy }}
+        ports:
+        - name: sqld
+          containerPort: {{ .Values.msDatabase.sqldPort }}
+          protocol: TCP
+        - name: viewer
+          containerPort: {{ .Values.msDatabase.viewerPort }}
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: {{ include "pvpipe.fullname" . }}-common-env
+        - configMapRef:
+            name: {{ .Release.Name }}-configmap
+            optional: true
+        - secretRef:
+            name: {{ .Release.Name }}-secret
+            optional: true
+        env:
+        - name: SQLD_PORT
+          value: "{{ .Values.msDatabase.sqldPort }}"
+        - name: VIEWER_PORT
+          value: "{{ .Values.msDatabase.viewerPort }}"
+        {{- range $key, $value := .Values.msDatabase.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        # Optional S3 backup configuration from secrets
+        - name: LIBSQL_BOTTOMLESS_BUCKET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: LIBSQL_BOTTOMLESS_BUCKET
+              optional: true
+        - name: LIBSQL_BOTTOMLESS_AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: LIBSQL_BOTTOMLESS_AWS_ACCESS_KEY_ID
+              optional: true
+        - name: LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY
+              optional: true
+        - name: LIBSQL_BOTTOMLESS_AWS_REGION
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: LIBSQL_BOTTOMLESS_AWS_REGION
+              optional: true
+        - name: LIBSQL_BOTTOMLESS_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: LIBSQL_BOTTOMLESS_ENDPOINT
+              optional: true
+        - name: SQLD_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: SQLD_AUTH_TOKEN
+              optional: true
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        resources:
+          {{- toYaml .Values.msDatabase.resources | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: sqld
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: sqld
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+  {{- if .Values.msDatabase.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+        {{- include "pvpipe.labels" . | nindent 8 }}
+        app.kubernetes.io/component: ms-database
+    spec:
+      accessModes:
+        - {{ .Values.msDatabase.persistence.accessMode | default "ReadWriteOnce" }}
+      resources:
+        requests:
+          storage: {{ .Values.msDatabase.persistence.size }}
+      {{- if .Values.msDatabase.persistence.storageClass }}
+      storageClassName: {{ .Values.msDatabase.persistence.storageClass }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/pvpipe/values.yaml
+++ b/charts/pvpipe/values.yaml
@@ -652,6 +652,34 @@ traefik:
         - retry
         - compress
         - cors
+    # MS-Database Service - SQLite/libSQL API
+    ms-database-api:
+      enabled: true
+      pathPrefix: /api/v1/database
+      stripPrefix: false
+      service: "{{ .Release.Name }}-ms-database"
+      port: 8080
+      protected: true  # Requires authentication
+      priority: 15
+      middlewares:
+        - rate-limit
+        - headers
+        - retry
+        - compress
+        - cors
+    # MS-Database Service - Web Viewer UI
+    ms-database-viewer:
+      enabled: true
+      pathPrefix: /database-viewer
+      stripPrefix: true
+      service: "{{ .Release.Name }}-ms-database"
+      port: 8090
+      protected: true  # Requires authentication
+      priority: 15
+      middlewares:
+        - rate-limit
+        - headers
+        - compress
   dashboard:
     enabled: false
   # Middleware configurations
@@ -716,6 +744,33 @@ traefik:
     domains: []
     options: ""
 
+
+# MS-Database Service (libSQL/sqld with sqlite-web viewer)
+msDatabase:
+  enabled: true
+  image:
+    repository: ms-database
+    tag: latest
+    pullPolicy: Always
+  replicas: 1
+  sqldPort: 8080
+  viewerPort: 8090
+  persistence:
+    enabled: true
+    size: 5Gi
+    storageClass: ""  # Leave empty to use default storage class
+    accessMode: ReadWriteOnce
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+    requests:
+      cpu: "250m"
+      memory: "256Mi"
+  env:
+    RUST_LOG: "info"
+    SQLD_PORT: "8080"
+    VIEWER_PORT: "8090"
 
 # MS-Notifications Microservice
 msNotifications:


### PR DESCRIPTION
## Summary
- Added ms-database service using libSQL/sqld with sqlite-web viewer
- Configured as StatefulSet with 5GB persistent storage for proper database lifecycle management
- Exposed database URLs through common environment configuration for all services

## Changes
- ✅ Added ms-database configuration to `values.yaml`
- ✅ Created StatefulSet manifest with volumeClaimTemplates 
- ✅ Created Service exposing sqld (8080) and viewer (8090) ports
- ✅ Updated common-env configmap with database URLs
- ✅ Added Traefik routes for API and viewer UI access
- ✅ Bumped chart version to 0.30.4

## Configuration Details
- **Image**: `ms-database:latest` (existing image)
- **Storage**: 5GB persistent volume
- **Ports**: 
  - 8080: sqld HTTP API
  - 8090: sqlite-web viewer UI
- **Environment URLs**:
  - `MS_DATABASE_URL`: Internal sqld API endpoint
  - `MS_DATABASE_VIEWER_URL`: Web UI endpoint
  - `SQLD_HTTP_URL`: Alternative API reference

## Test Plan
- [ ] Deploy to development environment
- [ ] Verify StatefulSet creates successfully
- [ ] Test database API connectivity at `/api/v1/database`
- [ ] Access viewer UI at `/database-viewer`
- [ ] Confirm environment variables are available to other services